### PR TITLE
fix: 'tender' data in tender_summary_with_data

### DIFF
--- a/sql/005-tender.sql
+++ b/sql/005-tender.sql
@@ -289,7 +289,7 @@ create view tender_summary_with_data
 AS
 select 
     ts.*, 
-    data -> 'tender' AS tender
+    COALESCE(data -> 'tender', data -> 'compiledRelease'-> 'tender') AS tender
 from 
     tender_summary ts
 join 


### PR DESCRIPTION
When we fetch the records the 'tender' data comes in the
'compiledRelease' key, so we need to get the first one that is not null.

Signed-off-by: Arturo Volpe <arturovolpe@gmail.com>